### PR TITLE
Allow Dispatching of Actions to be animated

### DIFF
--- a/Sources/UIExtensions/SwiftUI+SwiftRex/BindableViewModel.swift
+++ b/Sources/UIExtensions/SwiftUI+SwiftRex/BindableViewModel.swift
@@ -18,24 +18,28 @@ public struct BindableViewModel<Action, State> {
         self.viewModel = viewModel
     }
 
-    // TODO: Xcode 11.4 will allow us to use default arguments here.
-    // Right now, we need two separate subscripts 🤷‍♀️
-    // Besides, actionSource could be split into #file, #function, #line and optional info, so caller don't have to provide it
     /// Creates a lens binding to the viewModel, dispatching the action returned by the closure to the store on `set`,
     /// The  returned binding includes a local cache that will return the `set` value until the store updates.
-    public subscript<Value>(path: KeyPath<State, Value>, from actionSource: ActionSource, action: @escaping ((Value) -> Action?)) -> Binding<Value> {
-        .store(viewModel,
-               state: path,
-               file: actionSource.file,
-               function: actionSource.function,
-               line: actionSource.line,
-               info: actionSource.info,
-               onChange: action)
-    }
+    public subscript<Value>(
+        path: KeyPath<State, Value>,
+        changeModifier: ChangeModifier = .notAnimated,
+        file: String = #file,
+        function: String = #function,
+        line: UInt = #line,
+        info: String? = nil,
+        action: ((Value) -> Action?)? = nil) -> Binding<Value> {
+            if let actionClosure = action {
+                return .store(viewModel,
+                              state: path,
+                              changeModifier: changeModifier,
+                              file: file,
+                              function: function,
+                              line: line,
+                              info: info,
+                              onChange: actionClosure)
 
-    /// Returns a lens binding to the viewModel that can only be used to `get` values. All tries to `set` a
-    /// value are ignored, therefore no action is dispatched.
-    public subscript<Value>(path: KeyPath<State, Value>) -> Binding<Value> {
-        .getOnly(viewModel, state: path)
+            } else {
+                return .getOnly(viewModel, state: path)
+            }
     }
 }


### PR DESCRIPTION
I finally implemented the default arguments for subscripts. They are a bit weird, as they can only be at the end, and the argument names are removed. I had to fiddle a bit to make this work. 

But I like it a lot now :)

This allows to create bindings like this:

```swift
// Dispatches `select(preset: $0)` from an `withAnimation` block
viewModel.binding[\.selectedPreset, .animated] { .select(preset: $0) }
// Same as above, but does not trigger animation
viewModel.binding[\.selectedPreset] { .select(preset: $0) }
// Does not allow to change the value, only getting.
viewModel.binding[\.selectedPreset]
```


This is breaking change, so I'll release a 0.2.0 afterwards. 
