### PR TITLE
Fix ScrollableView ContentSize Calculation

### DIFF
--- a/Sources/UIExtensions/Components/SwiftUI/UIKit Wrappers/ScrollableView.swift
+++ b/Sources/UIExtensions/Components/SwiftUI/UIKit Wrappers/ScrollableView.swift
@@ -85,15 +85,23 @@ public final class UIScrollViewController<Content: View>: UIViewController, UISc
     }
 
     func updateScrollviewContentSize() {
-        var contentSize: CGSize = self.hostingController.view.intrinsicContentSize
-
+        // We need to determine the contentSize of the scrollview.
+        // First, create a bounding size. This is done by taking the scrollView's
+        // size and replacing one part, depending on scrollview axis, with
+        // greatestFiniteMagnitude.
+        var boundingSize = self.scrollView.frame.size
         switch axis {
         case .vertical:
-            contentSize.width = self.scrollView.frame.width
+            boundingSize.height = .greatestFiniteMagnitude
         case .horizontal:
-            contentSize.height = self.scrollView.frame.height
+            boundingSize.width = .greatestFiniteMagnitude
         }
 
+        // This allows the contentView to accurately calculate how much space
+        // in the axis' dimension it needs.
+        let contentSize = self.hostingController.view.sizeThatFits(boundingSize)
+
+        // This is then used as contentSize for the ScrollView.
         self.hostingController.view.frame.size = contentSize
         self.scrollView.contentSize = contentSize
     }
@@ -138,3 +146,4 @@ public final class UIScrollViewController<Content: View>: UIViewController, UISc
     }
 }
 #endif
+

--- a/Sources/UIExtensions/Extensions/CGSize+Extensions.swift
+++ b/Sources/UIExtensions/Extensions/CGSize+Extensions.swift
@@ -9,8 +9,8 @@
 import CoreGraphics
 
 extension CGSize {
-    /// Returns a `CGSize`with both parts set to `greatestFiniteMagnitude`.
+    /// Returns a `CGSize` with both parts set to `greatestFiniteMagnitude`.
     public static var greatestFiniteMagnitude: CGSize {
-        .init(width: CGFloat.greatestFiniteMagnitude, height: .greatestFiniteMagnitude)
+        .init(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
     }
 }

--- a/Sources/UIExtensions/Extensions/CGSize+Extensions.swift
+++ b/Sources/UIExtensions/Extensions/CGSize+Extensions.swift
@@ -1,0 +1,16 @@
+//
+//  CGSize+Extensions.swift
+//  UIExtensions
+//
+//  Created by Luis Reisewitz on 22.06.20.
+//  Copyright © 2020 Lautsprecher Teufel GmbH. All rights reserved.
+//
+
+import CoreGraphics
+
+extension CGSize {
+    /// Returns a `CGSize`with both parts set to `greatestFiniteMagnitude`.
+    public static var greatestFiniteMagnitude: CGSize {
+        .init(width: CGFloat.greatestFiniteMagnitude, height: .greatestFiniteMagnitude)
+    }
+}


### PR DESCRIPTION
The previous calculation just ignored one part of the size from `intrinsicContentSize`, but in our case the result was larger than the scrollView's width. Just decreasing the width makes it fit, but this could also make the result bigger in the other axis (think text: If you decrease the width of the text box, the text will just expand vertically).

This was fixed by using sizeThatFits instead of intrinsicContentSize and passing the correct bounding parameter (width or height, depending on scrollview axis).