### PR TITLE
Add View.debug() and Binding.debug() functions

### DIFF
--- a/Sources/UIExtensions/Extensions/Binding+Debug.swift
+++ b/Sources/UIExtensions/Extensions/Binding+Debug.swift
@@ -1,0 +1,45 @@
+//
+//  Binding+Debug.swift
+//  UIExtensions
+//
+//  Created by Luis Reisewitz on 11.12.20.
+//  Copyright © 2020 Lautsprecher Teufel GmbH. All rights reserved.
+//
+
+// The following additions are only to be used in Debug mode.
+#if DEBUG && canImport(SwiftUI)
+import SwiftUI
+
+extension Binding {
+    /// Returns a binding that allows to execute closures whenever the receiving binding is accessed.
+    /// Allows to print a message when the value is accessed and whenever a new value is set.
+    ///
+    /// Usage:
+    ///
+    ///     let newBinding = myBinding.debug { currentValue in
+    ///         print("Binding.get called. Current value: \(currentValue)")
+    ///     } onSet: { oldValue, newValue in
+    ///         print("Binding.set called. Old value: \(oldValue). New value: \(newValue)")
+    ///     }
+    ///
+    /// - Parameters:
+    ///   - onGet: Closure to execute whenever the value is accessed. This closure is passed the current
+    ///   value of the binding before it's returned to the caller.
+    ///   - onSet: Closure to execute whenever the value is changed. This closure is passed the old
+    ///   value and the new value respectively before the value is changed.
+    /// - Returns: Binding with same types, can be chained.
+    public func debug(onGet: ((Value) -> Void)? = nil,
+                      onSet: ((Value, Value) -> Void)? = nil)
+    -> Self {
+        .init {
+            let currentValue = self.wrappedValue
+            onGet?(currentValue)
+            return currentValue
+        } set: { newValue in
+            let oldValue = self.wrappedValue
+            onSet?(oldValue, newValue)
+            self.wrappedValue = newValue
+        }
+    }
+}
+#endif

--- a/Sources/UIExtensions/Extensions/View+Debug.swift
+++ b/Sources/UIExtensions/Extensions/View+Debug.swift
@@ -1,0 +1,31 @@
+//
+//  View+Debug.swift
+//  UIExtensions
+//
+//  Created by Luis Reisewitz on 11.12.20.
+//  Copyright © 2020 Lautsprecher Teufel GmbH. All rights reserved.
+//
+
+// The following additions are only to be used in Debug mode.
+#if DEBUG && canImport(SwiftUI)
+import SwiftUI
+
+extension View {
+    /// Allows to execute a function whenever this view is rendered. This is a useful helper for debugging
+    /// View state when rendering. Can be used to e.g. print something whenever this view is re-created
+    /// (the body is accessed).
+    ///
+    /// Usage:
+    ///
+    ///     .debug {
+    ///         print("Print something whenever view is rendered")
+    ///     }
+    ///
+    /// - Parameter closure: Closure to execute whenever this view hierarchy is created.
+    /// - Returns: The same view this was called, chainable.
+    public func debug(_ closure: () -> Void) -> Self {
+        closure()
+        return self
+    }
+}
+#endif


### PR DESCRIPTION
Both allow to execute a closure when the view is rendered or the Binding is accessed, respectively.

I use this a lot when debugging SwiftUI magic, so it should be here I think.