### PR TITLE
Xcode13: fix build problems on Xcode >= 13b3

### DIFF
--- a/Sources/UIExtensions/Helpers/ApplicationOpener.swift
+++ b/Sources/UIExtensions/Helpers/ApplicationOpener.swift
@@ -10,18 +10,19 @@
 import Foundation
 import UIKit
 
-public protocol ApplicationOpener {
-    static var openSettingsURLString: String { get }
+@objc
+public  protocol ApplicationOpener {
+    var openSettingsURL: String { get }
     func canOpenURL(_ url: URL) -> Bool
+    @available(iOSApplicationExtension, unavailable)
+    @objc(openURL:options:completionHandler:)
     func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?)
 }
 
-extension ApplicationOpener {
-    public var openSettingsURLString: String {
-        return Self.openSettingsURLString
-    }
-}
-
+@available(iOSApplicationExtension, unavailable)
 extension UIApplication: ApplicationOpener {
+    public var openSettingsURL: String {
+        Self.openSettingsURLString
+    }
 }
 #endif

--- a/Sources/UIExtensions/Helpers/ApplicationOpener.swift
+++ b/Sources/UIExtensions/Helpers/ApplicationOpener.swift
@@ -11,7 +11,7 @@ import Foundation
 import UIKit
 
 @objc
-public  protocol ApplicationOpener {
+public protocol ApplicationOpener {
     var openSettingsURL: String { get }
     func canOpenURL(_ url: URL) -> Bool
     @available(iOSApplicationExtension, unavailable)


### PR DESCRIPTION
Make the open method unavailable for AppExtensions explicitly, see
https://forums.swift.org/t/set-application-extension-api-only-on-a-spm-package/39333/19