### PR TITLE
update `.navigationDestination`

### DIFF
--- a/Sources/UIExtensions/Components/SwiftUI/Pure/NavigationStack.swift
+++ b/Sources/UIExtensions/Components/SwiftUI/Pure/NavigationStack.swift
@@ -2,14 +2,14 @@
 
 import SwiftUI
 
-struct NavigationStack<Content: View>: View {
+public struct NavigationStack<Content: View>: View {
     private let content: () -> Content
 
-    init(@ViewBuilder _ content: @escaping () -> Content) {
+    public init(@ViewBuilder _ content: @escaping () -> Content) {
         self.content = content
     }
 
-    var body: some View {
+    public var body: some View {
         if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
             SwiftUI.NavigationStack {
                 content()


### PR DESCRIPTION
- Drop `Equatable` conformance requirement in `.navgationDestination`'s generic `Value` type for iOS16.
we still need it for iOS15 to fix a bug.