### PR TITLE
Preview helpers.

### DIFF
--- a/Sources/UIExtensions/Components/SwiftUI/Pure/BindingProvider.swift
+++ b/Sources/UIExtensions/Components/SwiftUI/Pure/BindingProvider.swift
@@ -1,0 +1,20 @@
+// Copyright © 2023 Lautsprecher Teufel GmbH. All rights reserved.
+
+import SwiftUI
+
+struct BindingProvider<BindedState, Content: View>: View {
+    @State private var state: BindedState
+    private var content: (_ binding: Binding<BindedState>) -> Content
+
+    init(
+        _ initialState: BindedState,
+        @ViewBuilder content: @escaping (_ binding: Binding<BindedState>) -> Content
+    ) {
+        self.content = content
+        self._state = State(initialValue: initialState)
+    }
+
+    var body: some View {
+        content($state)
+    }
+}

--- a/Sources/UIExtensions/Extensions/PreviewProvider.swift
+++ b/Sources/UIExtensions/Extensions/PreviewProvider.swift
@@ -1,0 +1,33 @@
+// Copyright © 2023 Lautsprecher Teufel GmbH. All rights reserved.
+
+import SwiftUI
+
+#if DEBUG
+extension PreviewProvider {
+    @ViewBuilder
+    public static func withBinding<BindedState, Content: View>(
+        _ initialState: BindedState,
+        @ViewBuilder content: @escaping (_ binding: Binding<BindedState>) -> Content
+    ) -> some View {
+        BindingProvider(initialState, content: content)
+    }
+
+    @ViewBuilder
+    public static func withPreviewDevices<Content: View>(
+        _ deviceNames: [String]? = nil,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        if let deviceNames { PreviewHelper(deviceNames, content: content) }
+        else { PreviewHelper(content: content) }
+    }
+
+    @ViewBuilder
+    public static func withPreviewDevices<Content: View>(
+        _ deviceNames: [String]? = nil,
+        @ViewBuilder content: @escaping (String) -> Content
+    ) -> some View {
+        if let deviceNames { PreviewHelper(deviceNames, content: content) }
+        else { PreviewHelper(content: content) }
+    }
+}
+#endif

--- a/Sources/UIExtensions/SwiftUIPreviews/PreviewHelper.swift
+++ b/Sources/UIExtensions/SwiftUIPreviews/PreviewHelper.swift
@@ -3,15 +3,36 @@
 import SwiftUI
 
 #if DEBUG
-public struct PreviewHelper<V: View>: View {
-    private let view: (String) -> V
-    public init(@ViewBuilder view: @escaping (String) -> V) {
-        self.view = view
+public struct PreviewHelper<Content: View>: View {
+    private let devices: [String]
+    private let content: (String) -> Content
+    public static var defaultDevices: [String] {
+        [
+            "iPhone SE (3rd generation)",
+            "iPhone 14 Pro Max",
+            "iPad mini (6th generation)",
+            "iPad Pro (12.9-inch) (6th generation)"
+        ]
+    }
+    public init(
+        _ deviceNames: [String] = defaultDevices,
+        @ViewBuilder content: @escaping (String) -> Content
+    ) {
+        self.devices = deviceNames
+        self.content = content
+    }
+
+    public init(
+        _ deviceNames: [String] = defaultDevices,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.devices = deviceNames
+        self.content = { _ in content() }
     }
 
     public var body: some View {
-        ForEach(["iPhone SE (1st generation)", "iPhone X", "iPad Pro (12.9-inch) (4th generation)"], id: \.self) { device in
-            self.view(device)
+        ForEach(devices, id: \.self) { device in
+            self.content(device)
                 .previewDevice(.init(stringLiteral: device))
                 .previewDisplayName(device)
         }


### PR DESCRIPTION
- `PreviewHelper`
   - Default devices updated according to iOS 15+.
   - It is also possible to initialize with custom devices.
- `BindingProvider `
   - It is now easy to use binding states in previews.
- `PreviewProvider`
   - Extended for `PreviewHelper` and `BindingProvider` API.
