### PR TITLE
Implements a wait timeInterval 

### DIFF
--- a/Sources/SnapshotTestingExtensions/SnapshotTestBase.swift
+++ b/Sources/SnapshotTestingExtensions/SnapshotTestBase.swift
@@ -30,7 +30,8 @@ open class SnapshotTestBase: XCTestCase {
         imageDiffPrecision: Float = 1.0,
         file: StaticString = #file,
         testName: String = #function,
-        line: UInt = #line
+        line: UInt = #line,
+        wait: TimeInterval = 0.0
     ) {
         (devices ?? defaultDevices).forEach { config in
             style.forEach { uiStyle in
@@ -51,7 +52,7 @@ open class SnapshotTestBase: XCTestCase {
 
                 assertSnapshot(
                     matching: vc,
-                    as: .image(on: config.device, precision: imageDiffPrecision),
+                    as: .wait(for: wait, on: .image(on: config.device, precision: imageDiffPrecision)),
                     file: file,
                     testName: "\(testName)-\(config.name)\(suffix)",
                     line: line

--- a/Sources/SnapshotTestingExtensions/SnapshotTestBase.swift
+++ b/Sources/SnapshotTestingExtensions/SnapshotTestBase.swift
@@ -8,12 +8,12 @@ import XCTest
 
 open class SnapshotTestBase: XCTestCase {
     public var allowAnimations: Bool = false
-
+    
     override open func setUp() {
         super.setUp()
         UIView.setAnimationsEnabled(allowAnimations)
     }
-
+    
     open var defaultDevices: [(name: String, device: ViewImageConfig)] {
         [
             ("SE", .iPhoneSe),
@@ -22,7 +22,26 @@ open class SnapshotTestBase: XCTestCase {
             ("iPadPro", .iPadPro12_9(.portrait))
         ]
     }
-
+    
+    open func assertSnapshotDevices<V: View>(
+        _ view: V,
+        devices: [(name: String, device: ViewImageConfig)]? = nil,
+        style:  [UIUserInterfaceStyle] = [.unspecified],
+        imageDiffPrecision: Float = 1.0,
+        file: StaticString = #file,
+        testName: String = #function,
+        line: UInt = #line
+    ) {
+        (devices ?? defaultDevices).forEach { config in
+            assertSnapshotDevices(
+                view,
+                as: .image(on: config.device, precision: imageDiffPrecision),
+                style: style,
+                config: config
+            )
+        }
+    }
+    
     open func assertSnapshotDevices<V: View>(
         _ view: V,
         devices: [(name: String, device: ViewImageConfig)]? = nil,
@@ -31,33 +50,50 @@ open class SnapshotTestBase: XCTestCase {
         file: StaticString = #file,
         testName: String = #function,
         line: UInt = #line,
-        wait: TimeInterval = 0.0
+        wait: TimeInterval
     ) {
         (devices ?? defaultDevices).forEach { config in
-            style.forEach { uiStyle in
-                let vc = UIHostingController(rootView: view)
-                vc.overrideUserInterfaceStyle = uiStyle
-
-                let suffix: String
-                switch uiStyle {
-                case .unspecified:
-                    suffix = ""
-                case .light:
-                    suffix = "-light"
-                case .dark:
-                    suffix = "-dark"
-                @unknown default:
-                    fatalError("Unhandled UIUserInterfaceStyle \(uiStyle)")
-                }
-
-                assertSnapshot(
-                    matching: vc,
-                    as: .wait(for: wait, on: .image(on: config.device, precision: imageDiffPrecision)),
-                    file: file,
-                    testName: "\(testName)-\(config.name)\(suffix)",
-                    line: line
-                )
+            assertSnapshotDevices(
+                view,
+                as: .wait(for: wait, on: .image(on: config.device, precision: imageDiffPrecision)),
+                style: style,
+                config: config
+            )
+        }
+    }
+    
+    private func assertSnapshotDevices<V: View>(
+        _ view: V,
+        as snapshotting: Snapshotting<UIViewController, UIImage>,
+        style:  [UIUserInterfaceStyle] = [.unspecified],
+        config:  (name: String, device: ViewImageConfig),
+        file: StaticString = #file,
+        testName: String = #function,
+        line: UInt = #line
+    ) {
+        style.forEach { uiStyle in
+            let vc = UIHostingController(rootView: view)
+            vc.overrideUserInterfaceStyle = uiStyle
+            
+            let suffix: String
+            switch uiStyle {
+            case .unspecified:
+                suffix = ""
+            case .light:
+                suffix = "-light"
+            case .dark:
+                suffix = "-dark"
+            @unknown default:
+                fatalError("Unhandled UIUserInterfaceStyle \(uiStyle)")
             }
+            
+            assertSnapshot(
+                matching: vc,
+                as: snapshotting,
+                file: file,
+                testName: "\(testName)-\(config.name)\(suffix)",
+                line: line
+            )
         }
     }
 }


### PR DESCRIPTION
Implements a wait timeInterval which gets passed through to make use of the wait strategy when e.g. recording snapshots of views after an animation ran through or after an async image loaded